### PR TITLE
Paramterize tests to handle both C and script style comments.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ from setuptools import find_packages
 from setuptools import setup
 
 setup(name="polysquare-generic-file-linter",
-      version="0.0.11",
+      version="0.0.12",
       description="Polysquare Style Guide Linter",
       long_description_markdown_filename="README.md",
-      url="http://github.com/polysquare/polysquare-generic-file-linter",
       author="Sam Spilsbury",
       author_email="smspillaz@gmail.com",
+      url="http://github.com/polysquare/polysquare-generic-file-linter",
       classifiers=["Development Status :: 3 - Alpha",
                    "Programming Language :: Python :: 2",
                    "Programming Language :: Python :: 2.7",
@@ -32,6 +32,8 @@ setup(name="polysquare-generic-file-linter",
       install_requires=["setuptools"],
       extras_require={
           "test": ["coverage",
+                   "nose",
+                   "nose-parameterized",
                    "testtools"]
       },
       entry_points={
@@ -39,6 +41,6 @@ setup(name="polysquare-generic-file-linter",
               "polysquare-generic-file-linter=polysquarelinter.linter:main"
           ]
       },
-      test_suite="tests",
-      include_package_data=True,
-      zip_safe=True)
+      test_suite="nose.collector",
+      zip_safe=True,
+      include_package_data=True)


### PR DESCRIPTION
Also fixed a bug in replacements for copyright notices - correctly
handle the footer of the comment block in that case.