### PR TITLE
Don't run before_all functions unless any lint jobs would run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Status ##
 
-| Travis CI | AppVeyor | Coverage | PyPI |
-|-----------|----------|----------|------|
-|[![Travis](https://img.shields.io/travis/polysquare/polysquare-generic-file-linter.svg)]()|[![AppVeyor](https://img.shields.io/appveyor/ci/smspillaz/polysquare-generic-file-linter.svg)]()|[![Coveralls](https://img.shields.io/coveralls/polysquare/polysquare-generic-file-linter.svg)]()|[![PyPI](https://img.shields.io/pypi/v/polysquare-generic-file-linter.svg)]()[![PyPI](https://img.shields.io/pypi/pyversions/polysquare-generic-file-linter.svg)]()|[![License](https://img.shields.io/github/license/polysquare/polysquare-generic-file-linter.svg)]()|
+| Travis CI (Ubuntu) | AppVeyor (Windows) | Coverage | PyPI | Licence |
+|--------------------|--------------------|----------|------|---------|
+|[![Travis](https://img.shields.io/travis/polysquare/polysquare-generic-file-linter.svg)](http://travis-ci.org/polysquare/polysquare-generic-file-linter)|[![AppVeyor](https://img.shields.io/appveyor/ci/smspillaz/polysquare-generic-file-linter.svg)](https://ci.appveyor.com/project/smspillaz/polysquare-generic-file-linter)|[![Coveralls](https://img.shields.io/coveralls/polysquare/polysquare-generic-file-linter.svg)](http://coveralls.io/polysquare/polysquare-generic-file-linter)|[![PyPIVersion](https://img.shields.io/pypi/v/polysquare-generic-file-linter.svg)](https://pypi.python.org/pypi/polysquare-generic-file-linter)[![PyPIPythons](https://img.shields.io/pypi/pyversions/polysquare-generic-file-linter.svg)](https://pypi.python.org/pypi/polysquare-generic-file-linter)|[![License](https://img.shields.io/github/license/polysquare/polysquare-generic-file-linter.svg)](http://github.com/polysquare/polysquare-generic-file-linter)|
 
 Checks each file passed in for compliance with polysquare style guidelines.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ environment:
 
 cache:
  - C:\container -> appveyor.yml
- - C:\Python27 -> appveyor.yml
- - C:\Python34 -> appveyor.yml
 
 install:
  - ps: $env:PATH="${env:PYTHON};${env:PYTHON}/Scripts;${env:PATH};C:/MinGW/bin"

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,12 @@ setup(name="polysquare-generic-file-linter",
           ]
       },
       install_requires=[
-          "jobstamps>=0.0.8",
+          "jobstamps>=0.0.11",
           "parmap",
           "Whoosh<=2.6.0"
       ],
       extras_require={
-          "polysquarelint": ["polysquare-setuptools-lint>=0.0.16"],
+          "polysquarelint": ["polysquare-setuptools-lint>=0.0.22"],
           "green": [
               "nose",
               "nose-parameterized>=0.5.0",


### PR DESCRIPTION
The only before_all job and after_all jobs are for the spellcheck
linter and they all involve creating Whoosh dictionary
structures. This is an expensive process and is not necessary
if no jobs will run.