### PR TITLE
valid_words_dictionary: Add helper to pre-populate caches

### DIFF
--- a/polysquarelinter/linter.py
+++ b/polysquarelinter/linter.py
@@ -37,11 +37,10 @@ import parmap
 
 from polysquarelinter.spelling import (Dictionary,
                                        SpellcheckError,
-                                       read_dictionary_file,
                                        spellcheck_region,
                                        spellcheckable_and_shadow_contents,
-                                       technical_words_from_shadow_contents,
-                                       valid_words_set)
+                                       technical_words_from_shadow_contents,)
+import polysquarelinter.valid_words_dictionary as valid_words_dictionary_helper
 
 try:
     from Queue import Queue
@@ -339,19 +338,6 @@ def _find_spelling_errors_in_chunks(chunks,
                                            msg)
 
 
-def _create_valid_words_dictionary(spellchecker_cache_path):
-    """Create a Dictionary at spellchecker_cache_path with valid words."""
-    user_dictionary = os.path.join(os.getcwd(), "DICTIONARY")
-    user_words = read_dictionary_file(user_dictionary)
-
-    valid_words = Dictionary(valid_words_set(user_dictionary, user_words),
-                             "valid_words",
-                             [user_dictionary],
-                             spellchecker_cache_path)
-
-    return (user_words, valid_words)
-
-
 # suppress(invalid-name)
 def _create_technical_words_dictionary(spellchecker_cache_path,
                                        relative_path,
@@ -373,7 +359,7 @@ def _construct_user_dictionary(global_options, tool_options):
     del global_options
 
     spellchecker_cache_path = tool_options.get("spellcheck_cache", None)
-    _create_valid_words_dictionary(spellchecker_cache_path)
+    valid_words_dictionary_helper.create(spellchecker_cache_path)
 
 
 def _drain(queue_to_drain, sentinel=None):
@@ -433,7 +419,7 @@ def _no_spelling_errors(relative_path, contents, linter_options):
     chunks, shadow = spellcheckable_and_shadow_contents(contents,
                                                         block_regexps)
     cache = linter_options.get("spellcheck_cache", None)
-    user_words, valid_words = _create_valid_words_dictionary(cache)
+    user_words, valid_words = valid_words_dictionary_helper.create(cache)
     technical_words = _create_technical_words_dictionary(cache,
                                                          relative_path,
                                                          user_words,

--- a/polysquarelinter/valid_words_dictionary.py
+++ b/polysquarelinter/valid_words_dictionary.py
@@ -1,0 +1,45 @@
+# /polysquarelinter/valid_words_dictionary.py
+#
+# Helper module to create caches and a Dictionary for technical
+# words as well as regular english words.
+#
+# See /LICENCE.md for Copyright information
+"""Main module for linter."""
+
+import argparse
+
+import os
+
+import sys
+
+from polysquarelinter.spelling import (Dictionary,
+                                       read_dictionary_file,
+                                       valid_words_set)
+
+
+def create(spellchecker_cache_path):
+    """Create a Dictionary at spellchecker_cache_path with valid words."""
+    user_dictionary = os.path.join(os.getcwd(), "DICTIONARY")
+    user_words = read_dictionary_file(user_dictionary)
+
+    valid_words = Dictionary(valid_words_set(user_dictionary, user_words),
+                             "valid_words",
+                             [user_dictionary],
+                             spellchecker_cache_path)
+
+    return (user_words, valid_words)
+
+
+def _cause_cache_population():  # suppress(unused-function)
+    """Cause the cache to be populated with valid words."""
+    description = ("""Pre-populate cache for polysquare-generic-file-linter """
+                   """and spellcheck-linter.""")
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("cache_path",
+                        nargs="*",
+                        metavar=("PATH"),
+                        help="""PATH to cache""",
+                        type=str)
+    arguments = parser.parse_args(sys.argv[1:])
+    create(arguments.cache_path[0])
+    return 0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ setup(name="polysquare-generic-file-linter",
       entry_points={
           "console_scripts": [
               "polysquare-generic-file-linter=polysquarelinter.linter:main",
-              "spellcheck-linter=polysquarelinter.lint_spelling_only:main"
+              "spellcheck-linter=polysquarelinter.lint_spelling_only:main",
+              "polysquare-generic-file-linter-populate-cache="
+              "polysquarelinter.valid_words_dictionary:_cause_cache_population"
           ]
       },
       test_suite="nose.collector",


### PR DESCRIPTION
Added polysquare-generic-file-linter-populate-cache.

This is a script which should be run by target-based build-systems
before running polysquare-generic-file-linter to populate the
cache before any targets are run in parallel.