### PR TITLE
polysquarelinter: Use io.open to handle encoding and newlines correctly

### DIFF
--- a/polysquarelinter/lint_spelling_only.py
+++ b/polysquarelinter/lint_spelling_only.py
@@ -9,6 +9,8 @@ import argparse
 
 import hashlib
 
+import io
+
 import os
 
 import sys
@@ -122,7 +124,7 @@ def main(arguments=None):  # suppress(unused-function)
     num_errors = 0
     for found_filename in result.files:
         file_path = os.path.abspath(found_filename)
-        with open(file_path, "rb+") as found_file:
+        with io.open(file_path, "r+", encoding="utf-8") as found_file:
             jobstamps_dependencies = [file_path]
 
             if os.path.exists(dictionary_path):
@@ -138,7 +140,7 @@ def main(arguments=None):  # suppress(unused-function)
             }
 
             errors = jobstamp.run(spellcheck,
-                                  found_file.read().decode("utf-8"),
+                                  found_file.read(),
                                   result.technical_terms,
                                   result.spellcheck_cache,
                                   **kwargs)

--- a/polysquarelinter/linter.py
+++ b/polysquarelinter/linter.py
@@ -11,6 +11,8 @@ import errno
 
 import hashlib
 
+import io
+
 import itertools
 
 import multiprocessing
@@ -633,7 +635,7 @@ def _apply_replacement(error, found_file, file_lines):
 
     # Only fix one error at a time
     found_file.seek(0)
-    found_file.write(concatenated_fixed_lines.encode("utf-8"))
+    found_file.write(concatenated_fixed_lines)
     found_file.truncate()
 
 
@@ -718,8 +720,8 @@ def _run_lint_on_file(file_path,
     If fix_what_you_can is specified, then the first error that has a
     possible replacement will be automatically fixed on this file.
     """
-    with open(file_path, "rb+") as found_file:
-        file_contents = found_file.read().decode("utf-8")
+    with io.open(file_path, "r+", encoding="utf-8") as found_file:
+        file_contents = found_file.read()
         file_lines = file_contents.splitlines(True)
         try:
             errors = lint(file_path[len(os.getcwd()) + 1:],


### PR DESCRIPTION
Opening files in binary mode did not enable universal newlines, which
led to errors when checking files using regexes, since /r/n does not
match as the end of a line.