### PR TITLE
cache: Generate caches for both valid and technical words

### DIFF
--- a/polysquarelinter/cache_populate.py
+++ b/polysquarelinter/cache_populate.py
@@ -1,0 +1,33 @@
+# /polysquarelinter/cache_populate.py
+#
+# Populate caches before running multiple checker processes in parallel.
+#
+# See /LICENCE.md for Copyright information
+"""Populate caches before running multiple checker processes in parallel."""
+
+import argparse
+
+import sys
+
+from polysquarelinter import (technical_words_dictionary,
+                              valid_words_dictionary)
+
+
+def main():  # suppress(unused-function)
+    """Cause the cache to be populated with valid words."""
+    description = ("""Pre-populate cache for polysquare-generic-file-linter """
+                   """and spellcheck-linter.""")
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("cache_path",
+                        metavar=("PATH"),
+                        help="""PATH to cache""",
+                        type=str)
+    parser.add_argument("--technical-terms",
+                        metavar=("FILE"),
+                        help="""FILE containing technical terms""",
+                        type=str)
+    arguments = parser.parse_args(sys.argv[1:])
+    valid_words_dictionary.create(arguments.cache_path)
+    technical_words_dictionary.create(arguments.technical_terms,
+                                      arguments.cache_path)
+    return 0

--- a/polysquarelinter/lint_spelling_only.py
+++ b/polysquarelinter/lint_spelling_only.py
@@ -19,8 +19,10 @@ import tempfile
 
 from jobstamps import jobstamp
 
-from polysquarelinter import spelling
-from polysquarelinter.spelling import Dictionary, spellcheck_region
+from polysquarelinter import (spelling,
+                              technical_words_dictionary,
+                              valid_words_dictionary)
+from polysquarelinter.spelling import spellcheck_region
 
 
 def spellcheck(contents, technical_terms=None, spellcheck_cache=None):
@@ -39,27 +41,9 @@ def spellcheck(contents, technical_terms=None, spellcheck_cache=None):
     """
     contents = spelling.filter_nonspellcheckable_tokens(contents)
     lines = contents.splitlines(True)
-    user_dictionary = os.path.join(os.getcwd(), "DICTIONARY")
-    user_words = spelling.read_dictionary_file(user_dictionary)
-
-    valid_words = Dictionary(spelling.valid_words_set(user_dictionary,
-                                                      user_words),
-                             "valid_words",
-                             dictionary_sources=[user_dictionary],
-                             cache=spellcheck_cache)
-
-    # By default, include the user dictionary in the technical terms available.
-    technical_terms_set = user_words
-
-    if technical_terms:
-        with open(technical_terms) as tech_tf:
-            technical_terms_set |= set(tech_tf.read().splitlines())
-
-    technical_words = Dictionary(technical_terms_set,
-                                 "technical_words",
-                                 dictionary_sources=[technical_terms,
-                                                     user_dictionary],
-                                 cache=spellcheck_cache)
+    user_words, valid_words = valid_words_dictionary.create(spellcheck_cache)
+    technical_words = technical_words_dictionary.create(technical_terms,
+                                                        spellcheck_cache)
 
     return sorted([e for e in spellcheck_region(lines,
                                                 valid_words,

--- a/polysquarelinter/technical_words_dictionary.py
+++ b/polysquarelinter/technical_words_dictionary.py
@@ -1,0 +1,30 @@
+# /polysquarelinter/technical_words_dictionary.py
+#
+# Helper module to create caches and a Dictionary for technical
+# words.
+#
+# See /LICENCE.md for Copyright information
+"""Helper module to populate caches for technical words."""
+
+import os
+
+from polysquarelinter.spelling import (Dictionary,
+                                       read_dictionary_file)
+
+
+def create(technical_terms_filename, spellchecker_cache_path):
+    """Create a Dictionary at spellchecker_cache_path with technical words."""
+    user_dictionary = os.path.join(os.getcwd(), "DICTIONARY")
+    user_words = read_dictionary_file(user_dictionary)
+
+    technical_terms_set = set(user_words)
+
+    if technical_terms_filename:
+        with open(technical_terms_filename) as tech_tf:
+            technical_terms_set |= set(tech_tf.read().splitlines())
+
+    return Dictionary(technical_terms_set,
+                      "technical_words",
+                      dictionary_sources=[technical_terms_filename,
+                                          user_dictionary],
+                      cache=spellchecker_cache_path)

--- a/polysquarelinter/valid_words_dictionary.py
+++ b/polysquarelinter/valid_words_dictionary.py
@@ -1,16 +1,12 @@
 # /polysquarelinter/valid_words_dictionary.py
 #
-# Helper module to create caches and a Dictionary for technical
-# words as well as regular english words.
+# Helper module to create caches and a Dictionary for regular english words
+# and any user defined words.
 #
 # See /LICENCE.md for Copyright information
-"""Main module for linter."""
-
-import argparse
+"""Helper module to create caches for ordinary and user defined words."""
 
 import os
-
-import sys
 
 from polysquarelinter.spelling import (Dictionary,
                                        read_dictionary_file,
@@ -28,18 +24,3 @@ def create(spellchecker_cache_path):
                              spellchecker_cache_path)
 
     return (user_words, valid_words)
-
-
-def _cause_cache_population():  # suppress(unused-function)
-    """Cause the cache to be populated with valid words."""
-    description = ("""Pre-populate cache for polysquare-generic-file-linter """
-                   """and spellcheck-linter.""")
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("cache_path",
-                        nargs="*",
-                        metavar=("PATH"),
-                        help="""PATH to cache""",
-                        type=str)
-    arguments = parser.parse_args(sys.argv[1:])
-    create(arguments.cache_path[0])
-    return 0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name="polysquare-generic-file-linter",
               "polysquare-generic-file-linter=polysquarelinter.linter:main",
               "spellcheck-linter=polysquarelinter.lint_spelling_only:main",
               "polysquare-generic-file-linter-populate-cache="
-              "polysquarelinter.valid_words_dictionary:_cause_cache_population"
+              "polysquarelinter.cache_populate:main"
           ]
       },
       test_suite="nose.collector",


### PR DESCRIPTION
Build systems relying on the cache step would fall over
when attempting to read the technical words file which didn't
exist.