### PR TITLE
linter: Allow disabling of regions for spellcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ switch should be the path to a filename where technical terms are to be stored.
 On each invocation, the union of the current file contents and the technical
 terms detected will be written back to the file.
 
+#### Disabling regions from being spell-checked ####
+
+If you need to disable a region from being spell-checked, you can wrap it
+in triple-back-ticks, like so:
+
+```
+    content that is not spell-checked
+```
+
 ### Embedding the checking API ###
 
 The exported API in `polysquarelinter.spelling` isn't by any means stable

--- a/test/test_lint_spelling_only.py
+++ b/test/test_lint_spelling_only.py
@@ -160,7 +160,7 @@ class TestLintSpellingOnlyAcceptance(TestCase):
             self._run_with_cache(self._temporary_file)
 
             self.assertThat(captured.stdout,  # suppress(PYC70)
-                            Not(DocTestMatches("""...spelling_error] ...""",
+                            Not(DocTestMatches("...spelling_error] ...",
                                                doctest.ELLIPSIS |
                                                doctest.NORMALIZE_WHITESPACE |
                                                doctest.REPORT_NDIFF)))
@@ -174,7 +174,7 @@ class TestLintSpellingOnlyAcceptance(TestCase):
             self._run_with_cache(self._temporary_file)
 
             self.assertThat(captured.stdout,  # suppress(PYC70)
-                            Not(DocTestMatches("""...spelling_error] ...""",
+                            Not(DocTestMatches("...spelling_error] ...",
                                                doctest.ELLIPSIS |
                                                doctest.NORMALIZE_WHITESPACE |
                                                doctest.REPORT_NDIFF)))

--- a/test/test_spelling.py
+++ b/test/test_spelling.py
@@ -231,6 +231,28 @@ class TestSplitSpellcheckableFromShadowContents(TestCase):
 
         self.assertEqual(chunks[1].data[0], " checkable ")
 
+    def test_no_error_on_word_in_triple_backticks(self):
+        """No error for word in triple backticks."""
+        contents = "# ```splelling```\n".splitlines()
+        chunks, _ = spelling.spellcheckable_and_shadow_contents(contents)
+
+        self.assertThat(chunks[0].data[0], Not(Equals(" checkable ")))
+
+    def test_no_error_on_word_in_triple_backticks_multiline(self):
+        """No error for word in triple backticks (multi-line)."""
+        contents = "# ```splelling\n# splolling```".splitlines()
+        chunks, _ = spelling.spellcheckable_and_shadow_contents(contents)
+
+        self.assertThat(chunks[0].data[0], Not(Contains(" spelling ")))
+        self.assertThat(chunks[1].data[0], Not(Contains(" splolling ")))
+
+    def test_error_on_word_outside_triple_backticks(self):
+        """Find errors after backticks."""
+        contents = "# ```splelling```\n# splolling".splitlines()
+        chunks, _ = spelling.spellcheckable_and_shadow_contents(contents)
+
+        self.assertEqual(chunks[2].data[0], " splolling")
+
     def test_single_quoted_regions_found_in_shadow_contents(self):
         """Single quoted chunk is found in shadow contents."""
         contents = "# spellcheckable\n 'quoted' shadow".splitlines()

--- a/test/test_warnings.py
+++ b/test/test_warnings.py
@@ -529,6 +529,42 @@ class TestSpellingErrors(DisableStampingTestCase):
         self.assertTrue(result)
 
     @parameterized.expand(_KNOWN_STYLES)
+    def test_no_spelling_error_comments_blocked_region(self, style):
+        """No spelling errors where error is blocked out in comment."""
+        result = self._spellcheck_lint("{s}{e}\n{s} ```splelling```",
+                                       style)
+        self.assertTrue(result)
+
+    @parameterized.expand(_KNOWN_STYLES)
+    def test_no_spelling_error_comments_multiline_blocked_region(self, style):
+        """No spelling errors where error is multi-line blocked out."""
+        result = self._spellcheck_lint("{s}{e}\n"
+                                       "{s} ```splelling\n"
+                                       "{m} eror```{e}",
+                                       style)
+        self.assertTrue(result)
+
+    @parameterized.expand(_KNOWN_STYLES)
+    def test_no_persist_multiline_blocked_region(self, style):
+        """Don't persist multi-line blocked region."""
+        result = self._spellcheck_lint("{s}{e}\n"
+                                       "{s} ```splelling\n"
+                                       "{m} eror``` {e}\n"
+                                       "technical_term",
+                                       style)
+        self.assertTrue(result)
+
+    @parameterized.expand(_KNOWN_STYLES)
+    def test_no_persist_not_terminated_multiline_blocked_region(self, style):
+        """Don't persist multi-line blocked region, even if not terminated."""
+        result = self._spellcheck_lint("{s}{e}\n"
+                                       "{s} ```splelling\n"
+                                       "{m} eror {e}\n"
+                                       "technical_term",
+                                       style)
+        self.assertTrue(result)
+
+    @parameterized.expand(_KNOWN_STYLES)
     def test_no_spelling_error_inside_double_quoted_string(self, style):
         """No spelling errors inside single double-quote string."""
         result = self._spellcheck_lint("{s}{e}\n\"splelling\"",


### PR DESCRIPTION
As per some user requests, it is occasionally useful to be able to disable a region for spell-checking, for instance if it contains substantial code excerpts or examples which have tons of domain-specific words that we'd rather not add to the `DICTIONARY`. This change allows you to do that using the triple-backticks.