### PR TITLE
spelling: Don't eject from escaped region in multiline docstring

### DIFF
--- a/polysquarelinter/spelling.py
+++ b/polysquarelinter/spelling.py
@@ -428,7 +428,7 @@ class CommentSystemTransitions(object):
                 (0, 0),
                 None)
 
-    def should_terminate_now(self, line):
+    def should_terminate_now(self, line, waiting_for):
         """Whether parsing within a comment should terminate now.
 
         This is used for comment systems where there is no comment-ending
@@ -437,6 +437,9 @@ class CommentSystemTransitions(object):
         could end at a line ending. It returns true if, for a given line,
         line is not a comment.
         """
+        if waiting_for not in (ParserState.EOL, self._end):
+            return False
+
         if self._continue_regex:
             return (re.match(self._continue_regex, line) is None)
 
@@ -551,7 +554,10 @@ class DisabledParser(ParserState):
         # an explicit end marker. We can't detect line endings here because
         # we want a disabled region to continue across multiple lines.
         if (column == 0 and
-                comment_system_transitions.should_terminate_now(line)):
+                comment_system_transitions.should_terminate_now(
+                    line,
+                    self._resume_waiting_for
+                )):
             return (InTextParser(), 0, None)
 
         # Need to be a bit careful here, since we need to check what the

--- a/test/test_warnings.py
+++ b/test/test_warnings.py
@@ -545,6 +545,21 @@ class TestSpellingErrors(DisableStampingTestCase):
         self.assertTrue(result)
 
     @parameterized.expand(_KNOWN_STYLES)
+    def test_no_spelling_error_backticks_docstrings(self, style):
+        """No spelling errors inside docstring where blocked out."""
+        content = (
+            "{s}{e}\n"
+            "\"\"\"Header.\n"
+            "```\n"
+            "esssscaped"
+            "```\n"
+            "\"\"\"\n"
+            "technical_term\n"
+        )
+        result = self._spellcheck_lint(content, style)
+        self.assertTrue(result)
+
+    @parameterized.expand(_KNOWN_STYLES)
     def test_no_persist_multiline_blocked_region(self, style):
         """Don't persist multi-line blocked region."""
         result = self._spellcheck_lint("{s}{e}\n"


### PR DESCRIPTION
The escape condition was anything that wasn't a part of our
comment system, but docstrings are a special case, so handle
them as appropriate